### PR TITLE
Possibly add line break when processing wordwrap breakpoint

### DIFF
--- a/wordwrap/wordwrap.go
+++ b/wordwrap/wordwrap.go
@@ -135,6 +135,15 @@ func (w *WordWrap) Write(b []byte) (int, error) {
 			_, _ = w.space.WriteRune(c)
 		} else if inGroup(w.Breakpoints, c) {
 			// valid breakpoint
+
+			// add a line break if the current word plus this breakpoint would exceed
+			// the line's character limit
+			breakpointRuneWidth := 1 // printable rune width for any breakpoint
+			if w.lineLen+w.space.Len()+w.word.PrintableRuneWidth()+breakpointRuneWidth > w.Limit &&
+				w.word.PrintableRuneWidth() < w.Limit {
+				w.addNewLine()
+			}
+
 			w.addSpace()
 			w.addWord()
 			w.addBreakpoint(c)

--- a/wordwrap/wordwrap_test.go
+++ b/wordwrap/wordwrap_test.go
@@ -54,6 +54,20 @@ func TestWordWrap(t *testing.T) {
 			4,
 			true,
 		},
+		// A breakpoint causes wrapping when just adding it exceeds the limit:
+		{
+			"ab-cd-foo",
+			"ab-\ncd-\nfoo",
+			5,
+			true,
+		},
+		// A breakpoint with no preceding word counts towards when to wrap too:
+		{
+			"foo--bar--foo",
+			"foo-\n-\nbar-\n-foo",
+			4,
+			true,
+		},
 		// Space buffer needs to be emptied before breakpoints:
 		{
 			"foo --bar",


### PR DESCRIPTION
When word wrapping: Before a word plus its trailing separator (breakpoint) is added to a line, a check ensures that adding both will not exceed the limit. Without this check, it is possible that both are added when adding the word alone would exceed the limit, but adding both does. This would result in the line exceeding its limit.

This also fixes scenarios where a double separator could also grow a line beyond the limit.